### PR TITLE
Add a new "netsoft" viewer style and tweak it according to our needs.

### DIFF
--- a/app/assets/stylesheets/pdfjs_viewer/application.css
+++ b/app/assets/stylesheets/pdfjs_viewer/application.css
@@ -14,5 +14,6 @@
  *= require pdfjs_viewer/minimal
  *= require pdfjs_viewer/reduced
  *= require pdfjs_viewer/full
+ *= require pdfjs_viewer/netsoft
  *= require_self
  */

--- a/app/assets/stylesheets/pdfjs_viewer/netsoft.scss
+++ b/app/assets/stylesheets/pdfjs_viewer/netsoft.scss
@@ -1,0 +1,46 @@
+#pdfjs_viewer-netsoft {
+  .openFile { display: none;}
+
+  .bookmark { display: none; }
+
+  .outerCenter { display: none; }
+
+  .download { display: none; }
+
+  .pdfViewer {
+    padding-bottom: 20px;
+  }
+
+  #toolbarViewerLeft {
+    .toolbarButtonSpacer {
+      display: none;
+    }
+  }
+
+  #secondaryToolbarToggle {
+    display: none;
+  }
+
+  .verticalToolbarSeparator {
+    display: none;
+  }
+
+  .sidebarOpen {
+    .hiddenLargeView {
+      &.presentationMode {
+        display: block;
+      }
+    }
+    .hiddenMediumView {
+      &.print {
+        display: block;
+      }
+    }
+  }
+  #sidebarContent {
+    top: 0;
+  }
+  #toolbarSidebar {
+    display: none;
+  }
+}

--- a/app/controllers/pdfjs_viewer/viewer_controller.rb
+++ b/app/controllers/pdfjs_viewer/viewer_controller.rb
@@ -5,6 +5,9 @@ module PdfjsViewer
     def full
     end
 
+    def netsoft
+    end
+
     def minimal
     end
   end

--- a/app/views/pdfjs_viewer/viewer/netsoft.html.erb
+++ b/app/views/pdfjs_viewer/viewer/netsoft.html.erb
@@ -1,0 +1,1 @@
+<%= render "viewer", style: "netsoft" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ PdfjsViewer::Rails::Engine.routes.draw do
   get "minimal" => "viewer#minimal", as: :minimal
   get "reduced" => "viewer#reduced", as: :reduced
   get "full" => "viewer#full", as: :full
+  get "netsoft" => "viewer#netsoft", as: :netsoft
 end


### PR DESCRIPTION
Custom styled the pdf viewer to contain just the buttons we actually need.

- Sidebar toggler. Triggers a left sidebar which contains the document pages thumbnails.
- Find in document
- Next / Prev page buttons
- Page number fields
- Full screen button
- Print document button

Screenshot with the toolbar:
![image](https://cloud.githubusercontent.com/assets/1656477/20358965/93f44d64-ac36-11e6-9136-490eccd5c292.png)
