### PR TITLE
Corrects problem with unsafe Header

### DIFF
--- a/app/assets/javascripts/pdfjs_viewer/viewer.js
+++ b/app/assets/javascripts/pdfjs_viewer/viewer.js
@@ -7144,6 +7144,7 @@ window.PDFView = PDFViewerApplication; // obsolete name, using it as an alias
 
 var HOSTED_VIEWER_ORIGINS = ['null',
   'http://mozilla.github.io', 'https://mozilla.github.io'];
+var DISABLE_RANGE = false;
 function validateFileURL(file) {
   try {
     var viewerOrigin = new URL(window.location.href).origin || 'null';
@@ -7180,6 +7181,8 @@ function webViewerInitialized() {
   var params = parseQueryString(queryString);
   var file = 'file' in params ? params.file : DEFAULT_URL;
   validateFileURL(file);
+
+  PDFJS.disableRange = DISABLE_RANGE;
 
   var fileInput = document.createElement('input');
   fileInput.id = 'fileInput';

--- a/app/views/pdfjs_viewer/viewer/_viewer.html.erb
+++ b/app/views/pdfjs_viewer/viewer/_viewer.html.erb
@@ -43,6 +43,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <% end %>
     <%= javascript_include_tag "pdfjs_viewer/application" %>
     <%= javascript_tag "window.HOSTED_VIEWER_ORIGINS = #{PdfjsViewer.hosted_viewer_origins.to_json.html_safe};" %>
+    <%= javascript_tag "window.DISABLE_RANGE = #{PdfjsViewer.disable_range.to_json.html_safe};" %>
   </head>
 
   <body tabindex="1" class="loadingInProgress" id="pdfjs_viewer-<%= style %>">

--- a/lib/pdfjs_viewer-rails.rb
+++ b/lib/pdfjs_viewer-rails.rb
@@ -7,7 +7,11 @@ module PdfjsViewer
   mattr_accessor :hosted_viewer_origins do
     ['null', 'http://mozilla.github.io', 'https://mozilla.github.io']
   end
-  
+
+  mattr_accessor :disable_range do
+    false
+  end
+
   module Rails
     class Engine < ::Rails::Engine
       isolate_namespace PdfjsViewer


### PR DESCRIPTION

![screen shot 2016-11-23 at 16 37 58](https://cloud.githubusercontent.com/assets/756762/20570368/3c977194-b19b-11e6-9d9a-fd3da4754fd5.png)

This error is caused by amazon that don't accept this header, when we try fetch document there. This property already existed in PDFJS but was not accessible outside, i add it to be configure trough ruby:

`PdfjsViewer.disable_range = true`